### PR TITLE
Metadata changes

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -80,8 +80,6 @@ type SPSSODescriptor struct {
 	SingleLogoutService        []Endpoint        `xml:"SingleLogoutService"`
 	ManageNameIDService        []Endpoint
 	NameIDFormat               []string          `xml:"NameIDFormat"`
-	NameIDPolicy               []NameIDPolicy    `xml:"NameIDPolicy"`
-	Destination                string            `sml:"Destination"`
 	AssertionConsumerService   []IndexedEndpoint `xml:"AssertionConsumerService"`
 	AttributeConsumingService  []interface{}
 }

--- a/service_provider.go
+++ b/service_provider.go
@@ -93,11 +93,6 @@ func (sp *ServiceProvider) Metadata() *Metadata {
 				Location: sp.AcsURL,
 				Index:    1,
 			}},
-			NameIDPolicy: []NameIDPolicy{{
-				Format:      "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-				AllowCreate: true,
-			}},
-			Destination: sp.AcsURL,
 		},
 	}
 }


### PR DESCRIPTION
Generated metadata contained two fields, NameIDPolicy and Destination, added for pingFederate,
but these fields caused an error while setting up Keycloak. PingFederate works fine even without
these fields and removing these fields fixes the keycloak error.